### PR TITLE
Sequence With Mysql Test

### DIFF
--- a/demo/src/main/java/jp/snowday/tutorial/demo/infrastructure/persistence/mysql/mybatis/entity/PkTestEntity.java
+++ b/demo/src/main/java/jp/snowday/tutorial/demo/infrastructure/persistence/mysql/mybatis/entity/PkTestEntity.java
@@ -1,0 +1,23 @@
+package jp.snowday.tutorial.demo.infrastructure.persistence.mysql.mybatis.entity;
+
+
+import jp.snowday.tutorial.demo.infrastructure.util.annotation.Column;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 簡単なシーケンテスト用テーブル
+ * @author snowday
+ * @date 2018-10-6
+ */
+public class PkTestEntity {
+    @Getter
+    @Setter
+    @Column(name = "id")
+    private String id;
+
+    @Getter
+    @Setter
+    @Column(name = "hoge")
+    private String hoge;
+}

--- a/demo/src/main/java/jp/snowday/tutorial/demo/infrastructure/persistence/mysql/mybatis/entity/Sequence.java
+++ b/demo/src/main/java/jp/snowday/tutorial/demo/infrastructure/persistence/mysql/mybatis/entity/Sequence.java
@@ -1,0 +1,14 @@
+package jp.snowday.tutorial.demo.infrastructure.persistence.mysql.mybatis.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class Sequence {
+    @Getter
+    @Setter
+    private String seqName;
+
+    @Getter
+    @Setter
+    private Long value;
+}

--- a/demo/src/main/java/jp/snowday/tutorial/demo/infrastructure/persistence/mysql/mybatis/mapper/PkTestMapper.java
+++ b/demo/src/main/java/jp/snowday/tutorial/demo/infrastructure/persistence/mysql/mybatis/mapper/PkTestMapper.java
@@ -1,0 +1,17 @@
+package jp.snowday.tutorial.demo.infrastructure.persistence.mysql.mybatis.mapper;
+
+import jp.snowday.tutorial.demo.infrastructure.persistence.mysql.mybatis.entity.PkTestEntity;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+import java.util.List;
+
+@Mapper
+public interface PkTestMapper {
+    @Insert("Insert into id_table1(id, hoge) values(#{id}, #{hoge})")
+    void add(PkTestEntity entity);
+
+    @Select("Select id, hoge from id_table1")
+    List<PkTestEntity> getAll();
+}

--- a/demo/src/main/java/jp/snowday/tutorial/demo/infrastructure/persistence/mysql/mybatis/mapper/SequenceMapper.java
+++ b/demo/src/main/java/jp/snowday/tutorial/demo/infrastructure/persistence/mysql/mybatis/mapper/SequenceMapper.java
@@ -1,0 +1,22 @@
+package jp.snowday.tutorial.demo.infrastructure.persistence.mysql.mybatis.mapper;
+
+import jp.snowday.tutorial.demo.infrastructure.persistence.mysql.mybatis.entity.Sequence;
+import org.apache.ibatis.annotations.*;
+import org.apache.ibatis.mapping.StatementType;
+
+import javax.annotation.Nonnull;
+
+@Mapper
+public interface SequenceMapper {
+
+    @Results(value = {
+            @Result(column = "curr")
+    })
+    @Select("Select currseq(#{seqName}) AS curr")
+    Long currnetSeq(@Nonnull @Param("seqName") String seqName);
+
+
+    @Insert("call nextseq(#{seqName, mode=IN, jdbcType=VARCHAR, javaType=String}, #{value,mode=OUT,jdbcType=INTEGER})")
+    @Options(statementType = StatementType.CALLABLE)
+    void nextSeq(Sequence seqName);
+}

--- a/demo/src/main/java/jp/snowday/tutorial/demo/presentation/controller/PkController.java
+++ b/demo/src/main/java/jp/snowday/tutorial/demo/presentation/controller/PkController.java
@@ -1,0 +1,25 @@
+package jp.snowday.tutorial.demo.presentation.controller;
+
+import jp.snowday.tutorial.demo.infrastructure.persistence.mysql.mybatis.entity.PkTestEntity;
+import jp.snowday.tutorial.demo.usecase.PkTestUseCase;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@AllArgsConstructor
+public class PkController {
+    private PkTestUseCase pkTestUseCase;
+
+    @GetMapping("/add/")
+    public List<PkTestEntity> add() {
+        return pkTestUseCase.selfIncrement();
+    }
+
+    @GetMapping("/cur/")
+    public Long current() {
+        return pkTestUseCase.getCurrentVal();
+    }
+}

--- a/demo/src/main/java/jp/snowday/tutorial/demo/usecase/PkTestUseCase.java
+++ b/demo/src/main/java/jp/snowday/tutorial/demo/usecase/PkTestUseCase.java
@@ -1,0 +1,43 @@
+package jp.snowday.tutorial.demo.usecase;
+
+import jp.snowday.tutorial.demo.infrastructure.persistence.mysql.mybatis.entity.PkTestEntity;
+import jp.snowday.tutorial.demo.infrastructure.persistence.mysql.mybatis.entity.Sequence;
+import jp.snowday.tutorial.demo.infrastructure.persistence.mysql.mybatis.mapper.PkTestMapper;
+import jp.snowday.tutorial.demo.infrastructure.persistence.mysql.mybatis.mapper.SequenceMapper;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * シーケンスをテストするユースケース
+ * @author snowday
+ * @date 2018-10-6
+ */
+@Service
+@AllArgsConstructor
+@Transactional(rollbackFor = Exception.class)
+public class PkTestUseCase {
+    private SequenceMapper sequenceMapper;
+    private PkTestMapper pkTestMapper;
+
+    public List<PkTestEntity> selfIncrement() {
+
+        Sequence seq = new Sequence();
+        seq.setSeqName("seq_id_table1");
+        sequenceMapper.nextSeq(seq);
+
+        PkTestEntity e = new PkTestEntity();
+        e.setId(String.format("CC%08d", seq.getValue()));
+        e.setHoge(seq.getValue().toString());
+
+        pkTestMapper.add(e);
+        return pkTestMapper.getAll();
+    }
+
+
+    public Long getCurrentVal() {
+        return sequenceMapper.currnetSeq("seq_id_table1");
+    }
+}

--- a/testSeq.sql
+++ b/testSeq.sql
@@ -1,0 +1,68 @@
+USE `test` ;
+-- テスト用のテーブル
+DROP TABLE IF EXISTS `id_table1`;
+CREATE TABLE `id_table1` (
+  `id` varchar(10) NOT NULL,
+  `hoge` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+DROP TABLE IF EXISTS `id_table2`;
+CREATE TABLE `id_table2` (
+  `id` varchar(10) NOT NULL,
+  `fuga` varchar(50) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- シーケンステーブル
+DROP TABLE IF EXISTS `sequence`;
+CREATE TABLE `sequence` (
+  `seq_name` varchar(50) NOT NULL,
+  `current_val` int(11) NOT NULL,
+  `increment_val` int(11) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`seq_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO `sequence` VALUES ('seq_id_table1', '0', DEFAULT);
+INSERT INTO `sequence` VALUES ('seq_id_table2', '0', DEFAULT);
+
+-- nextval
+DROP PROCEDURE IF EXISTS `nextseq`;
+DELIMITER ;;
+CREATE PROCEDURE `nextseq`(
+  IN v_seq_name VARCHAR(50),
+  OUT ret int(11))
+begin
+-- START
+DECLARE exit handler for sqlexception
+  BEGIN
+    -- ERROR
+  ROLLBACK;
+END;
+
+DECLARE exit handler for sqlwarning
+ BEGIN
+    -- WARNING
+ ROLLBACK;
+END;
+ START TRANSACTION;
+ update sequence set current_val = current_val + increment_val where seq_name = v_seq_name;
+ select current_val into ret from sequence where seq_name = v_seq_name;
+ COMMIT;
+-- END
+end
+;;
+DELIMITER ;
+
+-- function
+DROP function if exists `currseq`;
+DELIMITER ;;
+CREATE FUNCTION `currseq` (v_seq_name VARCHAR(50)) RETURNS int(11)
+begin
+ declare ret integer;
+ set ret = 0; 
+ select current_val into ret from sequence where seq_name = v_seq_name;
+ return ret;
+end
+;;
+DELIMITER ;


### PR DESCRIPTION
# 目的
 - Oracleと同等なシーケンス機能をMysqlで実現し、Javaで使う

# 実現概要
## シーケンステーブル
```sql
DROP TABLE IF EXISTS `sequence`;
CREATE TABLE `sequence` (
  `seq_name` varchar(50) NOT NULL, -- シーケンス名
  `current_val` int(11) NOT NULL, -- 現在値
  `increment_val` int(11) NOT NULL DEFAULT '1', -- 毎回1で増分
  PRIMARY KEY (`seq_name`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

INSERT INTO `sequence` VALUES ('seq_id_table1', '0', DEFAULT);
```

## 発番PROCEDURE
```sql
DROP PROCEDURE IF EXISTS `nextseq`;
DELIMITER ;;
CREATE PROCEDURE `nextseq`(
  IN v_seq_name VARCHAR(50),
  OUT ret int(11))
begin
-- START
DECLARE exit handler for sqlexception
  BEGIN
    -- ERROR
  ROLLBACK;
END;

DECLARE exit handler for sqlwarning
 BEGIN
    -- WARNING
 ROLLBACK;
END;
 START TRANSACTION;
 update sequence set current_val = current_val + increment_val where seq_name = v_seq_name;
 select current_val into ret from sequence where seq_name = v_seq_name;
 COMMIT;
-- END
end
;;
DELIMITER ;
```

## 利用イメージ
```
mysql> call nextseq("seq_id_table1", @ret);
Query OK, 0 rows affected (0.01 sec)

mysql> select @ret;
+------+
| @ret |
+------+
|    7 |
+------+
1 row in set (0.01 sec)
```

# TODO
- 汚いコードを精緻化する